### PR TITLE
Allow arbitrary (private) metdata, and expose the quarantine information

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -56,4 +56,7 @@ jobs:
         python -m pip install mypy --editable .[test]
     - name: mypy
       run: |
+        if [[ "${{ matrix.python-version }}" == "3.7" ]]; then
+          sed -i "s/# only_py37: //" ./pyproject.toml
+        fi
         python -m mypy -p simple_repository

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,8 @@ static_analysis_wheel:
   before_script:
     - !reference [.acc_py_wheel_test, before_script]
     - python -m pip install $(ls -A ${project_root}/wheel-to-install/*.whl)[dev] mypy
+    # 3.7 version of mypy requires some specific configuration.
+    - '[[ "$PY_VERSION" == "3.7" ]] && sed -i "s/# only_py37: //" ./pyproject.toml'
   script:
     - python -m mypy -p simple_repository
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,4 @@ force_sort_within_sections = true
 python_version = "3.11"
 exclude = "simple_repository/tests"
 strict = true
+# only_py37: warn_unused_ignores = false

--- a/simple_repository/components/new_releases_remover.py
+++ b/simple_repository/components/new_releases_remover.py
@@ -40,6 +40,7 @@ class NewReleasesRemover(core.RepositoryContainer):
         *,
         request_context: model.RequestContext = model.RequestContext.DEFAULT,
     ) -> model.ProjectDetail:
+
         project_page = await super().get_project_page(
             project_name,
             request_context=request_context,
@@ -71,8 +72,10 @@ class NewReleasesRemover(core.RepositoryContainer):
                 if seconds_since_release >= self._quarantine_time.total_seconds():
                     files_to_maintain.append(file)
                 else:
-                    files_to_be_removed.append(file)
+                    files_to_be_removed.append(file.filename)
 
+        # Note that we don't remove the version from the versions list on project page.
+        # PEP-700 states that we are allowed to have a release without any files in it.
         return dataclasses.replace(
             project_page,
             files=tuple(files_to_maintain),

--- a/simple_repository/components/new_releases_remover.py
+++ b/simple_repository/components/new_releases_remover.py
@@ -40,7 +40,6 @@ class NewReleasesRemover(core.RepositoryContainer):
         *,
         request_context: model.RequestContext = model.RequestContext.DEFAULT,
     ) -> model.ProjectDetail:
-
         project_page = await super().get_project_page(
             project_name,
             request_context=request_context,

--- a/simple_repository/model.py
+++ b/simple_repository/model.py
@@ -74,7 +74,7 @@ def _allow_underscore_attributes_on_dataclass(
         if private_kwargs:
             # If we have some private fields, then update the instance's dataclass fields attribute
             # so that calls such as dataclasses.replace can persist these private attributes.
-            updated_fields = self.__dataclass_fields__.copy()
+            updated_fields = getattr(self, "__dataclass_fields__").copy()
             for kwarg in private_kwargs:
                 f = dataclasses.field()
                 f.name = kwarg
@@ -91,11 +91,11 @@ def _allow_underscore_attributes_on_dataclass(
     @functools.wraps(orig_eq)
     def new_eq(self: _DataclassType, other: typing.Any) -> bool:
         if type(other) is type(self):
-            self_fields = set(self.__dataclass_fields__)
-            other_fields = set(other.__dataclass_fields__)
+            self_fields = set(getattr(self, "__dataclass_fields__"))
+            other_fields = set(getattr(other, "__dataclass_fields__"))
             if self_fields != other_fields:
                 return False
-            for name in set(self.__dataclass_fields__) | set(other.__dataclass_fields__):
+            for name in self_fields:
                 if not getattr(self, name) == getattr(other, name):
                     return False
             return True

--- a/simple_repository/model.py
+++ b/simple_repository/model.py
@@ -103,6 +103,15 @@ def _allow_underscore_attributes_on_dataclass(
 
     cls.__eq__ = new_eq  # type: ignore[assignment]
 
+    def new_repr(self: _DataclassType) -> str:
+        args = ', '.join([
+            f'{field.name}={getattr(self, field.name)!r}'
+            for field in getattr(self, '__dataclass_fields__').values()
+        ])
+        return f'{type(self).__name__}({args})'
+
+    cls.__repr__ = new_repr  # type: ignore[assignment]
+
     return cls
 
 

--- a/simple_repository/model.py
+++ b/simple_repository/model.py
@@ -81,7 +81,7 @@ def _allow_underscore_attributes_on_dataclass(
     @functools.wraps(orig_eq)
     def new_eq(self: _DataclassType, other: typing.Any) -> bool:
         if type(other) is type(self):
-            return self.__dict__ == other.__dict__
+            return self.__dict__ == other.__dict__  # type: ignore[no-any-return]
         return NotImplemented  # type: ignore[no-any-return]
 
     cls.__eq__ = new_eq  # type: ignore[assignment]

--- a/simple_repository/parser.py
+++ b/simple_repository/parser.py
@@ -95,12 +95,17 @@ def parse_json_project_page(body: str) -> model.ProjectDetail:
             ),
         )
 
+    versions = page_dict.get('versions', None)
+    if versions is not None:
+        versions = set(versions)
+
     return model.ProjectDetail(
         name=page_dict["name"],
         meta=model.Meta(
             api_version=page_dict["meta"]["api-version"],
         ),
         files=tuple(files),
+        versions=versions,
     )
 
 

--- a/simple_repository/parser.py
+++ b/simple_repository/parser.py
@@ -21,13 +21,16 @@ def parse_json_project_list(page: str) -> model.ProjectList:
     projects = frozenset(
         model.ProjectListElement(
             name=project.get("name"),
+            **_gather_private_attribs(project),
         ) for project in project_dict["projects"]
     )
     return model.ProjectList(
         meta=model.Meta(
             api_version=project_dict["meta"]["api-version"],
+            **_gather_private_attribs(project_dict["meta"]),
         ),
         projects=projects,
+        **_gather_private_attribs(project_dict),
     )
 
 
@@ -57,6 +60,10 @@ def parse_html_project_list(page: str) -> model.ProjectList:
         ),
         projects=projects,
     )
+
+
+def _gather_private_attribs(element: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+    return {name: value for name, value in element.items() if name.startswith("_")}
 
 
 def parse_json_project_page(body: str) -> model.ProjectDetail:
@@ -92,6 +99,7 @@ def parse_json_project_page(body: str) -> model.ProjectDetail:
                 yanked=file.get("yanked"),
                 size=file.get("size"),
                 upload_time=upload_time,
+                **_gather_private_attribs(file),
             ),
         )
 
@@ -103,9 +111,11 @@ def parse_json_project_page(body: str) -> model.ProjectDetail:
         name=page_dict["name"],
         meta=model.Meta(
             api_version=page_dict["meta"]["api-version"],
+            **_gather_private_attribs(page_dict["meta"]),
         ),
         files=tuple(files),
         versions=versions,
+        **_gather_private_attribs(page_dict),
     )
 
 

--- a/simple_repository/serializer.py
+++ b/simple_repository/serializer.py
@@ -57,7 +57,7 @@ class SerializerJsonV1(Serializer):
                 model.ProjectListElement,
             ],
             target: typing.Dict[str, typing.Any],
-    ):
+    ) -> None:
         for name in model.__dataclass_fields__:
             if name.startswith("_"):
                 target[name] = getattr(model, name)
@@ -82,7 +82,7 @@ class SerializerJsonV1(Serializer):
 
     def _standardize_project_list(
             self,
-            project_list: model.ProjectList,
+            project_list: model.ProjectListElement,
     ) -> typing.Dict[str, typing.Any]:
         result = {"name": project_list.name}
         # Include the private metadata verbatim, as per PEP-700:

--- a/simple_repository/tests/components/test_new_releases_remover.py
+++ b/simple_repository/tests/components/test_new_releases_remover.py
@@ -46,6 +46,7 @@ def test_exclude_recent_distributions__old_files() -> None:
     now = datetime(2023, 1, 1)
     project_detail = create_project_detail(datetime(1926, 1, 1), datetime(2000, 1, 4))
     new_project_detail = repository._exclude_recent_distributions(project_detail, now)
+    assert new_project_detail.__dict__.pop('_quarantined_files') == ()
     assert new_project_detail == project_detail
 
 
@@ -61,6 +62,7 @@ def test_exclude_recent_distributions__new_files() -> None:
     assert new_project_detail != project_detail
     assert len(new_project_detail.files) == 1
     assert new_project_detail.files[0].upload_time == now - timedelta(days=11)
+    assert len(new_project_detail._quarantined_files) == 2
 
 
 @pytest.mark.asyncio

--- a/simple_repository/tests/components/test_new_releases_remover.py
+++ b/simple_repository/tests/components/test_new_releases_remover.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import datetime, timedelta
 import typing
 from unittest import mock
@@ -46,8 +47,7 @@ def test_exclude_recent_distributions__old_files() -> None:
     now = datetime(2023, 1, 1)
     project_detail = create_project_detail(datetime(1926, 1, 1), datetime(2000, 1, 4))
     new_project_detail = repository._exclude_recent_distributions(project_detail, now)
-    assert new_project_detail.__dict__.pop('_quarantined_files') == ()
-    assert new_project_detail == project_detail
+    assert new_project_detail == dataclasses.replace(project_detail, _quarantined_files=())
 
 
 def test_exclude_recent_distributions__new_files() -> None:

--- a/simple_repository/tests/test_model.py
+++ b/simple_repository/tests/test_model.py
@@ -133,16 +133,20 @@ def test_ProjectDetail__manual_versions() -> None:
                 size=1,
             ),
         ),
+        versions={'1.0', '2.0', "1.2.3"},
     )
-    assert project_detail.versions == {'1.0', '2.0'}
-    pd2 = dataclasses.replace(project_detail, versions=project_detail.versions | {'1.2.3'})
-    # Now check that it persists with some other replacement.
-    pd3 = dataclasses.replace(pd2)
+    # Versions should persist with other replacement.
+    pd1 = dataclasses.replace(project_detail)
 
-    assert pd2.versions == {
+    assert pd1.versions == {
         "1.0", "2.0", "1.2.3",
     }
-    assert pd2.versions == pd3.versions
+
+    # And we should be able to get it to be generated again by setting it to None.
+    pd2 = dataclasses.replace(project_detail, versions=None)
+    assert pd2.versions == {
+        "1.0", "2.0",
+    }
 
 
 def test__File__arbitrary_private_metadata() -> None:

--- a/simple_repository/tests/test_model.py
+++ b/simple_repository/tests/test_model.py
@@ -80,36 +80,32 @@ def test_ProjectDetail__post_init_v1_1() -> None:
             ),
         ),
     )
-    assert project_detail.versions == {
+    assert project_detail.versions == (
         "1.0", "2.0",
-    }
+    )
 
 
 def test_ProjectDetail__versions_subset() -> None:
-    message = (
-        'The versions specified in ProjectDetail does not include all of '
-        'the versions that can be found in the files'
-    )
-    with pytest.raises(ValueError, match=message):
-        model.ProjectDetail(
-            meta=model.Meta("1.1"),
-            name="pippo",
-            files=(
-                model.File(
-                    filename="pippo-1.0.tar.gz",
-                    url="url",
-                    hashes={},
-                    size=1,
-                ),
-                model.File(
-                    filename="pippo-2.0-anylinux-py3.whl",
-                    url="url",
-                    hashes={},
-                    size=1,
-                ),
+    detail = model.ProjectDetail(
+        meta=model.Meta("1.1"),
+        name="pippo",
+        files=(
+            model.File(
+                filename="pippo-1.0.tar.gz",
+                url="url",
+                hashes={},
+                size=1,
             ),
-            versions={'1.0'},
-        )
+            model.File(
+                filename="pippo-2.0-anylinux-py3.whl",
+                url="url",
+                hashes={},
+                size=1,
+            ),
+        ),
+        versions=('1.0',),
+    )
+    assert detail.versions == ('1.0', '2.0')
 
 
 def test_ProjectDetail__manual_versions() -> None:
@@ -133,20 +129,16 @@ def test_ProjectDetail__manual_versions() -> None:
                 size=1,
             ),
         ),
-        versions={'1.0', '2.0', "1.2.3"},
+        versions=('1.0', '2.0', "1.2.3"),
     )
     # Versions should persist with other replacement.
     pd1 = dataclasses.replace(project_detail)
 
-    assert pd1.versions == {
-        "1.0", "2.0", "1.2.3",
-    }
+    assert pd1.versions == ('1.0', '2.0', "1.2.3")
 
     # And we should be able to get it to be generated again by setting it to None.
     pd2 = dataclasses.replace(project_detail, versions=None)
-    assert pd2.versions == {
-        "1.0", "2.0",
-    }
+    assert pd2.versions == ("1.0", "2.0")
 
 
 def test__File__arbitrary_private_metadata() -> None:

--- a/simple_repository/tests/test_model.py
+++ b/simple_repository/tests/test_model.py
@@ -81,3 +81,67 @@ def test_ProjectDetail__post_init_v1_1() -> None:
     assert project_detail.versions == {
         "1.0", "2.0",
     }
+
+
+def test__File__aribtrary_private_metadata() -> None:
+    file = model.File(
+        filename="pippo",
+        url="url",
+        hashes={},
+        _foo='bar',
+    )
+    assert file._foo == 'bar'
+
+
+def test__File__eq__private_metadata() -> None:
+    file = model.File(
+        filename="pippo",
+        url="url",
+        hashes={},
+        _foo='bar',
+    )
+    file2 = model.File(
+        filename="pippo",
+        url="url",
+        hashes={},
+    )
+    assert file != file2
+    assert file == file
+
+
+@pytest.mark.xfail(strict=True)
+def test__File__hash__private_metadata() -> None:
+    file = model.File(
+        filename="pippo",
+        url="url",
+        hashes={},
+        _foo='bar',
+    )
+    file2 = model.File(
+        filename="pippo",
+        url="url",
+        hashes={},
+    )
+    assert hash(file) != hash(file2)
+
+
+@pytest.mark.xfail(strict=True)
+def test__File__hash() -> None:
+    file = model.File(
+        filename="pippo",
+        url="url",
+        hashes={},
+    )
+    # The file should be hashable (it is frozen after all), but we currently
+    # allow dict to be passed.
+    hash(file)
+
+
+def test__File__no_aribtrary_public_metadata() -> None:
+    with pytest.raises(TypeError, match=r'unexpected keyword argument .?foo.?'):
+        model.File(
+            filename="pippo",
+            url="url",
+            hashes={},
+            foo='bar',
+        )

--- a/simple_repository/tests/test_parser.py
+++ b/simple_repository/tests/test_parser.py
@@ -331,6 +331,37 @@ def test_parse_json_project_list() -> None:
     )
 
 
+def test_parse_json_project_list__private() -> None:
+    page = '''
+    {
+        "meta": {
+            "api-version": "1.0",
+            "_extra_meta": 123
+        },
+        "projects": [
+            {
+                "name": "gym",
+                "_extra_project": 123
+            },
+            {
+                "name": "my_project"
+            }
+        ],
+        "_extra_list": 123
+    }'''
+
+    result = parser.parse_json_project_list(page)
+
+    assert result == model.ProjectList(
+        model.Meta("1.0", _extra_meta=123),
+        frozenset([
+            model.ProjectListElement("gym", _extra_project=123),
+            model.ProjectListElement("my_project"),
+        ]),
+        _extra_list=123,
+    )
+
+
 def test_parse_html_project_list() -> None:
     page = '''
         <a href="url">gym</a>
@@ -394,4 +425,58 @@ def test_parse_json_project_page__v_1_1() -> None:
                 upload_time=datetime(2000, 1, 1, 0, 0, 0),
             ),
         ),
+    )
+
+
+def test_parse_json_project_page__private() -> None:
+    page = '''
+    {
+        "meta": {
+            "api-version": "1.1",
+            "_extra_meta": 123
+        },
+        "name": "holygrail",
+        "files": [
+            {
+                "filename": "holygrail-1.0-py3-none-any.whl",
+                "url": "http://url.whl",
+                "hashes": {},
+                "size": 1,
+                "upload-time": "2000-01-01T00:00:00.000000Z",
+                "_extra_file": 123
+            },
+            {
+                "filename": "holygrail-1.1-py3-none-any.whl",
+                "url": "http://url.whl",
+                "hashes": {},
+                "size": 1,
+                "upload-time": "2000-01-01T00:00:00Z"
+            }
+        ],
+        "_extra_project_page": 123
+    }'''
+
+    result = parser.parse_json_project_page(page)
+
+    assert result == model.ProjectDetail(
+        model.Meta("1.1", _extra_meta=123),
+        "holygrail",
+        (
+            model.File(
+                filename="holygrail-1.0-py3-none-any.whl",
+                url="http://url.whl",
+                hashes={},
+                size=1,
+                upload_time=datetime(2000, 1, 1, 0, 0, 0),
+                _extra_file=123,
+            ),
+            model.File(
+                filename="holygrail-1.1-py3-none-any.whl",
+                url="http://url.whl",
+                hashes={},
+                size=1,
+                upload_time=datetime(2000, 1, 1, 0, 0, 0),
+            ),
+        ),
+        _extra_project_page=123,
     )

--- a/simple_repository/tests/test_parser.py
+++ b/simple_repository/tests/test_parser.py
@@ -87,6 +87,41 @@ def test_parse_json_project_page() -> None:
     )
 
 
+def test_parse_json_project_page__additional_versions() -> None:
+    # Check that if we recieve the versions flag (PEP-700), we persist it.
+    # It shouldn't always be auto-computed.
+    page = '''
+    {
+        "meta": {
+            "api-version": "1.0"
+        },
+        "name": "holygrail",
+        "files": [
+            {
+                "filename": "holygrail-1.0.tar.gz",
+                "url": "https://example.com/files/holygrail-1.0.tar.gz",
+                "hashes": {}
+            }
+        ],
+        "versions": ["1.0", "2.0"]
+    }'''
+
+    result = parser.parse_json_project_page(page)
+
+    assert result == model.ProjectDetail(
+        model.Meta("1.0"),
+        "holygrail",
+        (
+            model.File(
+                filename="holygrail-1.0.tar.gz",
+                url="https://example.com/files/holygrail-1.0.tar.gz",
+                hashes={},
+            ),
+        ),
+        versions={"1.0", "2.0"},
+    )
+
+
 def test_parse_html_project_page() -> None:
     page = '''
         <a href="holygrail-1.0.tar.gz#sha256=..."

--- a/simple_repository/tests/test_serializer.py
+++ b/simple_repository/tests/test_serializer.py
@@ -292,6 +292,46 @@ def test_serialize_project_page_json__v1_1_attrs(
     assert json.loads(res)["files"] == json.loads(serialization)
 
 
+def test_serialize_project_page_json__private_attrs() -> None:
+    serialization = '''{
+      "meta": {
+        "api-version": "1.1",
+        "_meta_extra": "abc"
+      },
+      "name": "project",
+      "versions": [
+        "1.2.3"
+      ],
+      "files": [
+        {
+          "filename": "test1-1.2.3-any.whl",
+          "url": "test1.whl",
+          "hashes": {},
+          "size": 1,
+          "_file_extra": 123
+        }
+      ],
+      "_page_extra": 456
+    }'''
+    page = model.ProjectDetail(
+        model.Meta("1.1", _meta_extra="abc"),
+        "project",
+        files=(
+            model.File(
+                filename="test1-1.2.3-any.whl",
+                url="test1.whl",
+                hashes={},
+                size=1,
+                _file_extra=123,
+            ),
+        ),
+        _page_extra=456,
+    )
+    serializer = SerializerJsonV1()
+    res = serializer.serialize_project_page(page)
+    assert json.loads(res) == json.loads(serialization)
+
+
 def test_serialize_project_list_json() -> None:
     page = model.ProjectList(
         model.Meta("1.0"),
@@ -310,5 +350,30 @@ def test_serialize_project_list_json() -> None:
         "projects": [
             {"name": "a"}
         ]
+    }'''),
+    )
+
+
+def test_serialize_project_list_json__with_extra() -> None:
+    page = model.ProjectList(
+        model.Meta("1.0", _extra_meta="abc"),
+        projects=frozenset([
+            model.ProjectListElement("a", _extra_list_element=123),
+        ]),
+        _extra_project_list=456,
+    )
+    serializer = SerializerJsonV1()
+    res = serializer.serialize_project_list(page)
+
+    assert res == json.dumps(
+        json.loads('''{
+        "meta": {
+            "api-version": "1.0",
+            "_extra_meta": "abc"
+        },
+        "projects": [
+            {"name": "a", "_extra_list_element": 123}
+        ],
+        "_extra_project_list": 456
     }'''),
     )


### PR DESCRIPTION
This PR does a few things:

* Allows you to explicitly control the `versions` element of the project detail page. This is specified in PEP-700: "The versions key MAY contain versions with no associated files"
* Supports parsing of JSON with `versions` defined (not essential for this PR, but ensures consistency)
* Allows the models to have arbitrary private metadata, as per PEP-700: "Keys (at any level) with a leading underscore are reserved as private for index server use. No future standard will assign a meaning to any such key."
* Private attributes are parsed through the JSON parser. This is needed for the browser to be able to consume the values that a quarantining repository serves
* Publishes the private attributes through JSON serialisation
* Updates the `new_release_remover` to put the filenames that it removes in a special private `_quarantined_files` attribute