### PR TITLE
Only compute the versions when they aren't specified

### DIFF
--- a/simple_repository/model.py
+++ b/simple_repository/model.py
@@ -147,14 +147,20 @@ class ProjectDetail:
                     raise ValueError(
                         "SimpleAPI>=1.1 requires the size field to be set for all the files.",
                     )
-            computed_versions = frozenset(
-                str(safe_version(file.filename, self._normalized_name))
-                for file in self.files
-            )
-            # If we were given some versions already, follow the rules of PEP-700 and ensure
-            # that they include our computed versions.
-            versions = computed_versions | (self.versions or set())
-            object.__setattr__(self, "versions", versions)
+            if self.versions is None:
+                versions = self.compute_versions_from_files(self.files, self._normalized_name)
+                object.__setattr__(self, "versions", versions)
+
+    @classmethod
+    def compute_versions_from_files(
+            cls,
+            files: typing.Tuple[File, ...],
+            normalized_name: str,
+    ) -> typing.FrozenSet[str]:
+        return frozenset(
+            str(safe_version(file.filename, normalized_name))
+            for file in files
+        )
 
     @property
     def _normalized_name(self) -> str:

--- a/simple_repository/parser.py
+++ b/simple_repository/parser.py
@@ -98,6 +98,9 @@ def parse_json_project_page(body: str) -> model.ProjectDetail:
                 private_metadata=_gather_private_attribs(file),
             ),
         )
+    versions = page_dict.get('versions', None)
+    if versions is not None:
+        versions = frozenset(versions)
 
     return model.ProjectDetail(
         name=page_dict["name"],
@@ -106,6 +109,7 @@ def parse_json_project_page(body: str) -> model.ProjectDetail:
             private_metadata=_gather_private_attribs(page_dict["meta"]),
         ),
         files=tuple(files),
+        versions=versions,
         private_metadata=_gather_private_attribs(page_dict),
     )
 

--- a/simple_repository/tests/test_model.py
+++ b/simple_repository/tests/test_model.py
@@ -105,7 +105,9 @@ def test_ProjectDetail__versions_subset() -> None:
         ),
         versions=frozenset({'1.0'}),
     )
-    assert detail.versions == {'1.0', '2.0'}
+    # When we have a subset of versions specified (not spec compliant), we don't
+    # do any magic, but we also don't raise.
+    assert detail.versions == {'1.0'}
 
 
 def test_ProjectDetail__manual_versions() -> None:

--- a/simple_repository/tests/test_parser.py
+++ b/simple_repository/tests/test_parser.py
@@ -129,6 +129,41 @@ def test_parse_html_project_page() -> None:
     )
 
 
+def test_parse_json_project_page__additional_versions() -> None:
+    # Check that if we receive the versions flag (PEP-700), we persist it.
+    # It shouldn't always be auto-computed.
+    page = '''
+    {
+        "meta": {
+            "api-version": "1.0"
+        },
+        "name": "holygrail",
+        "files": [
+            {
+                "filename": "holygrail-1.0.tar.gz",
+                "url": "https://example.com/files/holygrail-1.0.tar.gz",
+                "hashes": {}
+            }
+        ],
+        "versions": ["1.0", "2.0"]
+    }'''
+
+    result = parser.parse_json_project_page(page)
+
+    assert result == model.ProjectDetail(
+        model.Meta("1.0"),
+        "holygrail",
+        (
+            model.File(
+                filename="holygrail-1.0.tar.gz",
+                url="https://example.com/files/holygrail-1.0.tar.gz",
+                hashes={},
+            ),
+        ),
+        versions=frozenset({"1.0", "2.0"}),
+    )
+
+
 @pytest.mark.parametrize(
     "fragment_attr, hashes",
     [


### PR DESCRIPTION
In addition: ensure that we bring through the version information from the JSON response