### PR TITLE
Move resource fetching to the File object

### DIFF
--- a/simple_repository/components/http.py
+++ b/simple_repository/components/http.py
@@ -115,8 +115,21 @@ class HttpRepository(core.SimpleRepository):
             dataclasses.replace(file, url=utils.url_absolutizer(file.url, page_url))
             for file in project_page.files
         )
+        import functools
+        for file in files:
+            object.__setattr__(file, '_fetcher', functools.partial(self._fetch_file, file.url))
+            # print('Replaced: ', file._fetcher)
         project_page = dataclasses.replace(project_page, files=files)
         return project_page
+
+    @override
+    async def resolve_file(self, project, filename):
+        ...
+
+    @classmethod
+    async def _fetch_file(cls, url: str, *, request_context: model.RequestContext) -> bytes:
+        return b'f'
+        # raise NotImplementedError()
 
     @override
     async def get_project_list(

--- a/simple_repository/components/priority_selected.py
+++ b/simple_repository/components/priority_selected.py
@@ -79,7 +79,7 @@ class PrioritySelectedProjectsRepository(core.SimpleRepository):
 
         if len(project_lists) != len(self.sources):
             # TODO: Use an exception group to raise
-            # multiple exceptions together.
+            #   multiple exceptions together.
             any_exception = next(item for item in results if isinstance(item, BaseException))
             raise any_exception
 

--- a/simple_repository/tests/integration/test_simple_repository_core.py
+++ b/simple_repository/tests/integration/test_simple_repository_core.py
@@ -1,0 +1,90 @@
+import pytest
+
+from simple_repository import model
+from simple_repository._typing_compat import override
+from simple_repository.components.core import RepositoryContainer, SimpleRepository
+
+
+class CustomSource(SimpleRepository):
+    # Simulates a resource which exists.
+    @override
+    async def get_resource(
+        self,
+        project_name: str,
+        resource_name: str,
+        *,
+        request_context: model.RequestContext = model.RequestContext.DEFAULT,
+    ) -> model.Resource:
+        return model.TextResource('abc')
+
+
+class FileExtender(RepositoryContainer):
+    # Simulates the ability to extend a resource.
+    @override
+    async def get_resource(
+            self,
+            project_name: str,
+            resource_name: str,
+            *,
+            request_context: model.RequestContext = model.RequestContext.DEFAULT,
+    ) -> model.Resource:
+        resource = await super().get_resource(
+            project_name, resource_name,
+            request_context=request_context,
+        )
+        if resource_name.endswith('.metadata'):
+            return resource
+
+        assert isinstance(resource, model.TextResource)
+        assert resource.text == 'abc'
+        return model.TextResource('abc-def')
+
+
+class ResourceExtractor(RepositoryContainer):
+    # Simulates the ability to produce derivative resources (e.g. metadata from a wheel).
+    @override
+    async def get_resource(
+            self,
+            project_name: str,
+            resource_name: str,
+            *,
+            request_context: model.RequestContext = model.RequestContext.DEFAULT,
+    ) -> model.Resource:
+        if resource_name.endswith('.metadata'):
+            parent_resource_name = resource_name[:-len('.metadata')]
+            parent_resource = await self.get_resource(project_name, parent_resource_name, request_context=request_context)
+            assert isinstance(parent_resource, model.TextResource)
+            return model.TextResource(parent_resource.text[::-1])
+        else:
+            return await super().get_resource(
+                project_name, resource_name,
+                request_context=request_context,
+            )
+
+
+@pytest.mark.asyncio
+async def test_resource_chaining_order():
+    # A repository which implements resource derivative calculation (such as is possible with metadata injector), and then afterwards the original file is extended. The derivative shouldn't take into account the modified file.
+    repo = FileExtender(
+        ResourceExtractor(
+            CustomSource(),
+        ),
+    )
+    r = await repo.get_resource('foo', 'bar')
+    assert isinstance(r, model.TextResource)
+    assert r.text == 'abc-def'
+
+    r = await repo.get_resource('foo', 'bar.metadata')
+    assert isinstance(r, model.TextResource)
+    assert r.text == 'cba'
+
+    # If we switch the order of the components, the extractor should use the extended file.
+    repo = ResourceExtractor(
+        FileExtender(
+            CustomSource(),
+        ),
+    )
+
+    r = await repo.get_resource('foo', 'bar.metadata')
+    assert isinstance(r, model.TextResource)
+    assert r.text == 'fed-cba'


### PR DESCRIPTION
This means we can avoid re-computing (potentially erroneously) the repository graph, and we do not need to have an intermediate representation of a resource - every File object can get its bytes.

Other noteworthy changes:

 * [ ] We no longer need the metaclass to guarantee get_resource has the "leaf" repository (and I've added a test to ensure that we don't reach to the leaf repository when making a sub-request for a file (e.g. when computing the .metadata file, we need the full file)
 * [ ] `get_resource` is now redundant. it is the same as `get_project_page`, then filtering for the `File` of interest, then calling the `read_bytes` method on that. In fact, this is what simple-repository-server will have to do, since it doesn't have File objects.
 * [ ] Adds behaviour to the `File` object. This is the first time that we have behaviour on our models... and it is a bit weird still - when you parse html, you don't have such behaviour on the File (since the parser doesn't know how to download URLs). This could be straightened out still.
 * [ ] Implemented the functionality across all components