### PR TITLE
Fix PrioritySelectedProjectsRepository resource retrieval to follow first-seen policy

### DIFF
--- a/simple_repository/components/core.py
+++ b/simple_repository/components/core.py
@@ -165,14 +165,23 @@ class SimpleRepository(metaclass=SimpleRepositoryMeta):
 
         Raises
         ------
-        error.ResourceUnavailable:
-            When no such resource exists.
+        errors.PackageNotFoundError:
+            When the project does not exist in this repository.
+        errors.ResourceUnavailable:
+            When the project exists but the specific resource does not exist.
         model.NotModified:
             When sufficient request context is provided, it is possible for the
             repository to raise a NotModified exception to indicate that the
             result that corresponds to the given cache headers is still valid.
         errors.SourceRepositoryUnavailable:
             When the upstream repository is not available.
+
+        Notes
+        -----
+
+        Repositories should distinguish between two failure cases:
+        1. Project does not exist: raise PackageNotFoundError
+        2. Project exists but resource does not exist: raise ResourceUnavailable
 
         """
         raise NotImplementedError()

--- a/simple_repository/components/http.py
+++ b/simple_repository/components/http.py
@@ -153,7 +153,7 @@ class HttpRepository(core.SimpleRepository):
                 request_context=request_context,
             )
         except errors.PackageNotFoundError:
-            raise errors.ResourceUnavailable(resource_name)
+            raise
 
         resource: typing.Optional[model.HttpResource] = None
         if resource_name.endswith(".metadata"):

--- a/simple_repository/tests/components/fake_repository.py
+++ b/simple_repository/tests/components/fake_repository.py
@@ -54,6 +54,13 @@ class FakeRepository(core.SimpleRepository):
         *,
         request_context: model.RequestContext = model.RequestContext.DEFAULT,
     ) -> model.Resource:
+        # Check if we have this project first
+        try:
+            await self.get_project_page(project_name, request_context=request_context)
+        except errors.PackageNotFoundError:
+            raise
+
+        # Look for the specific resource
         resource = self.resources.get(resource_name)
         if resource:
             return resource

--- a/simple_repository/tests/components/test_http_repository.py
+++ b/simple_repository/tests/components/test_http_repository.py
@@ -333,7 +333,7 @@ async def test_get_resource_unavailable(project_detail: model.ProjectDetail, htt
 async def test_get_resource_project_unavailable(httpx_mock: pytest_httpx.HTTPXMock) -> None:
     repository = HttpRepository(url="https://example.com/simple/")
     with mock.patch.object(repository, "get_project_page", side_effect=errors.PackageNotFoundError("numpy")):
-        with pytest.raises(errors.ResourceUnavailable, match="numpy-3.0.whl"):
+        with pytest.raises(errors.PackageNotFoundError, match="numpy"):
             await repository.get_resource("numpy", "numpy-3.0.whl")
 
 

--- a/simple_repository/tests/components/test_priority_selected_repo.py
+++ b/simple_repository/tests/components/test_priority_selected_repo.py
@@ -212,14 +212,28 @@ async def test_get_resource__resource_exists_but_not_package() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_resource__subresource() -> None:
+async def test_get_resource__subresource_exists_in_lower_priority() -> None:
     group_repository = PrioritySelectedProjectsRepository([
         FakeRepository(
+            project_pages=[
+                model.ProjectDetail(
+                    meta=model.Meta("1.0"),
+                    name="numpy",
+                    files=(),
+                ),
+            ],
             resources={
                 "numpy.whl": model.HttpResource("url"),
             },
         ),
         FakeRepository(
+            project_pages=[
+                model.ProjectDetail(
+                    meta=model.Meta("1.0"),
+                    name="numpy",
+                    files=(),
+                ),
+            ],
             resources={
                 "numpy.whl": model.HttpResource("undesirable1"),
                 "numpy.whl.metadata": model.HttpResource("undesirable2"),
@@ -264,10 +278,10 @@ async def test_get_resource__first_repo_has_project_but_missing_resource() -> No
 
 
 @pytest.mark.asyncio
-async def test_get_resource_failed() -> None:
+async def test_get_resource__no_package() -> None:
     group_repository = PrioritySelectedProjectsRepository([
         FakeRepository() for _ in range(3)
     ])
 
-    with pytest.raises(errors.ResourceUnavailable, match="numpy.whl"):
+    with pytest.raises(errors.PackageNotFoundError, match="numpy"):
         await group_repository.get_resource("numpy", "numpy.whl")

--- a/simple_repository/tests/components/test_repository_container.py
+++ b/simple_repository/tests/components/test_repository_container.py
@@ -47,6 +47,9 @@ async def test_get_project_list() -> None:
 async def test_get_resource() -> None:
     repository = RepositoryContainer(
         FakeRepository(
+            project_pages=[
+                model.ProjectDetail(model.Meta("1.0"), "numpy", files=()),
+            ],
             resources={
                 "numpy.whl": model.HttpResource("numpy_url"),
             },

--- a/simple_repository/tests/components/test_resource_cache.py
+++ b/simple_repository/tests/components/test_resource_cache.py
@@ -30,6 +30,13 @@ def repository(tmp_path: pathlib.Path) -> ResourceCacheRepository:
     not_to_cache_resource = model.HttpResource("url/uncacheable-1.0-any.whl", to_cache=False)
     not_to_cache_resource.context["etag"] = "etag"
     source = FakeRepository(
+        project_pages=[
+            model.ProjectDetail(model.Meta("1.0"), "http", files=()),
+            model.ProjectDetail(model.Meta("1.0"), "local", files=()),
+            model.ProjectDetail(model.Meta("1.0"), "http-no-etag", files=()),
+            model.ProjectDetail(model.Meta("1.0"), "uncacheable", files=()),
+            model.ProjectDetail(model.Meta("1.0"), "resource", files=()),
+        ],
         resources={
             "http-1.0-any.whl": http_resource,
             "local-1.0.tar.gz": model.LocalResource(pathlib.Path("path")),
@@ -291,7 +298,12 @@ async def test_get_resource__no_cache_created_when_to_cache_is_false(
     resource.context["etag"] = "etag"
 
     repository = ResourceCacheRepository(
-        source=FakeRepository(resources={"resource-1.0-any.whl": resource}),
+        source=FakeRepository(
+            project_pages=[
+                model.ProjectDetail(model.Meta("1.0"), "resource", files=()),
+            ],
+            resources={"resource-1.0-any.whl": resource},
+        ),
         cache_path=tmp_path,
         http_client=mock.MagicMock(),
     )


### PR DESCRIPTION
The get_resource method was incorrectly searching across all repositories for a resource, but should follow the same first-seen policy as get_project_page.

In the wild, I saw this when we released a wheel internally with the same name as one on pypi. Our one didn't include a metadata file, and when we went to fetch the metadata it was being taken from the pypi one. The result was incorrect dependencies on install.