### PR TITLE
Fix the LocalRepository to raise PackageNotFound when it does not have the project at all

### DIFF
--- a/simple_repository/components/local.py
+++ b/simple_repository/components/local.py
@@ -95,6 +95,7 @@ class LocalRepository(core.SimpleRepository):
         repository_uri = (self._index_path / project_name).resolve()
         resource_uri = (repository_uri / resource_name).resolve()
 
+        # Validate both paths for security (path traversal prevention)
         if (
             not utils.is_relative_to(repository_uri, self._index_path) or
             not utils.is_relative_to(resource_uri, repository_uri)
@@ -102,6 +103,12 @@ class LocalRepository(core.SimpleRepository):
             raise ValueError(
                 f"{resource_uri} is not contained in {repository_uri}",
             )
+
+        # Check if project directory exists
+        if not repository_uri.is_dir():
+            raise errors.PackageNotFoundError(project_name)
+
+        # Check if resource file exists
         if not resource_uri.is_file():
             raise errors.ResourceUnavailable(resource_name)
 

--- a/simple_repository/tests/components/test_local_repository.py
+++ b/simple_repository/tests/components/test_local_repository.py
@@ -80,27 +80,28 @@ async def test_get_resource(simple_dir: pathlib.Path) -> None:
     )
 
 
-@pytest.mark.parametrize(
-    ("project, resource"), [
-        ("numpy", "numpy-2.0.tar.gz"),
-        ("seaborn", "seaborn-1.0.tar.gz"),
-    ],
-)
 @pytest.mark.asyncio
-async def test_get_resource__unavailable(
-    simple_dir: pathlib.Path,
-    project: str,
-    resource: str,
-) -> None:
-    repo = LocalRepository(
-        index_path=simple_dir,
-    )
+async def test_get_resource__unavailable(simple_dir: pathlib.Path) -> None:
+    """Test when project exists but resource doesn't exist."""
+    repo = LocalRepository(index_path=simple_dir)
 
     with pytest.raises(
         errors.ResourceUnavailable,
-        match=f"Resource '{resource}' was not found in the configured source",
+        match="Resource 'numpy-2.0.tar.gz' was not found in the configured source",
     ):
-        await repo.get_resource(project, resource)
+        await repo.get_resource("numpy", "numpy-2.0.tar.gz")
+
+
+@pytest.mark.asyncio
+async def test_get_resource__project_not_found(simple_dir: pathlib.Path) -> None:
+    """Test when project doesn't exist at all."""
+    repo = LocalRepository(index_path=simple_dir)
+
+    with pytest.raises(
+        errors.PackageNotFoundError,
+        match="Package 'seaborn' was not found in the configured source",
+    ):
+        await repo.get_resource("seaborn", "seaborn-1.0.tar.gz")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a follow-up to https://github.com/simple-repository/simple-repository/pull/32.