### PR TITLE
Implement MergedRepository.get_resource

### DIFF
--- a/simple_repository/components/priority_selected.py
+++ b/simple_repository/components/priority_selected.py
@@ -114,9 +114,10 @@ class PrioritySelectedProjectsRepository(core.SimpleRepository):
     ) -> model.Resource:
         """Retrieves a resource from the first source that has the project.
 
-        This follows the same first-seen policy as get_project_page. Repositories
-        are expected to raise PackageNotFoundError when they don't have the project,
-        and ResourceUnavailable when they have the project but not the resource.
+        This follows the same first-seen project policy as get_project_page.
+        Repositories are expected to raise PackageNotFoundError when they don't
+        have the project, and ResourceUnavailable when they have the project but
+        not the resource.
         """
         for source in self.sources:
             try:

--- a/simple_repository/tests/components/test_merged_repo.py
+++ b/simple_repository/tests/components/test_merged_repo.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from ... import errors, model
+from ...components.core import SimpleRepository
 from ...components.merged import MergedRepository
 from .fake_repository import FakeRepository
 
@@ -120,3 +121,72 @@ async def test_get_project_page_failed() -> None:
         match="Package 'numpy' was not found in the configured source",
     ):
         await repo.get_project_page("numpy")
+
+
+@pytest.fixture
+def resource_repo_t1() -> SimpleRepository:
+    repo = MergedRepository([
+        FakeRepository(
+            project_pages=[
+                model.ProjectDetail(
+                    model.Meta("1.0"),
+                    "numpy",
+                    files=(),
+                ),
+            ],
+            # First repo has project page but no resources
+        ),
+        FakeRepository(
+            project_pages=[
+                model.ProjectDetail(
+                    model.Meta("1.0"),
+                    "numpy",
+                    files=(),
+                ),
+            ],
+            resources={
+                "numpy-1.0.whl": model.HttpResource("from_second_repo"),
+            },
+        ),
+        FakeRepository(
+            project_pages=[
+                model.ProjectDetail(
+                    model.Meta("1.0"),
+                    "numpy",
+                    files=(),
+                ),
+            ],
+            resources={
+                "numpy-1.0.whl": model.HttpResource("from_third_repo"),
+                "numpy-1.1.whl": model.HttpResource("from_third_repo"),
+                "numpy-1.0.whl.metadata": model.HttpResource("from_third_repo"),
+            },
+        ),
+    ])
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_get_resource__wrong_project_name(resource_repo_t1: SimpleRepository) -> None:
+    # Should find resource from second repo (first one that has it).
+    resource = await resource_repo_t1.get_resource("numpy", "numpy-1.0.whl")
+    assert resource == model.HttpResource("from_second_repo")
+
+
+@pytest.mark.asyncio
+async def test_get_resource__searches_all_sources(resource_repo_t1: SimpleRepository) -> None:
+    # Should find resource from second repo even though first repo exists
+    resource = await resource_repo_t1.get_resource("numpy", "numpy-1.0.whl")
+    assert resource == model.HttpResource("from_second_repo")
+
+    resource = await resource_repo_t1.get_resource("numpy", "numpy-1.0.whl.metadata")
+    assert resource == model.HttpResource("from_third_repo")
+
+
+@pytest.mark.asyncio
+async def test_get_resource__not_found(resource_repo_t1: SimpleRepository) -> None:
+    with pytest.raises(errors.ResourceUnavailable, match="missing.whl"):
+        await resource_repo_t1.get_resource("numpy", "missing.whl")
+
+    with pytest.raises(errors.PackageNotFoundError, match="missing-project"):
+        await resource_repo_t1.get_resource("missing-project", "missing.whl")


### PR DESCRIPTION
Implement `MergedRepository.get_resource`, which previously wasn't need…ed due to the buggy behaviour of `PrioritySelectedProjectsRepository.get_resource` (which was fixed in https://github.com/simple-repository/simple-repository/pull/32)